### PR TITLE
Fix details/summary visual glitch in Firefox

### DIFF
--- a/_app/assets/_scss/_user.scss
+++ b/_app/assets/_scss/_user.scss
@@ -100,6 +100,7 @@
   details {
 
     summary {
+      list-style: none;
 
       &:focus,
       &:hover {


### PR DESCRIPTION
This removes the details/summary arrow in Firefox as it's overlapping the custom '+' one.

Compare

![overlapping arrow/plus sign](https://user-images.githubusercontent.com/664779/45211907-d0ee1280-b293-11e8-996d-a3c36f2ceedc.png)

with
![only plus sign](https://user-images.githubusercontent.com/664779/45211917-d5b2c680-b293-11e8-942f-e26004390743.png)
